### PR TITLE
Navbar: collapse at 1200px to prevent overflow, hide mobile toggle on desktop

### DIFF
--- a/static/css/hugo-academic-group.css
+++ b/static/css/hugo-academic-group.css
@@ -78,7 +78,7 @@ body {
     padding-top: 0;
     counter-reset: captions;
 }
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1200px) {
     body {
         /* Offset body content by navbar height. */
         margin-top: 51px;
@@ -900,7 +900,7 @@ nav#navbar-main li {
     text-decoration: none;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1200px) {
     .navbar {
         min-height: 50px !important;
     }
@@ -977,9 +977,10 @@ nav#navbar-main li {
     }
 }
 
-@media screen and (min-width: 1001px) {
-    .theme-toggle-navbar-mobile {
-        display: none;
+@media screen and (min-width: 1201px) {
+    #navbar-main .theme-toggle-navbar-mobile,
+    .navbar .theme-toggle-navbar-mobile {
+        display: none !important;
     }
 }
 


### PR DESCRIPTION
- Raise navbar collapse breakpoint from 1000px to 1200px so menus stay in hamburger at 1000-1200px
- Hide mobile theme toggle above 1200px (min-width: 1201px) with stronger selectors