### PR TITLE
Update TML 2026 course page for semester start

### DIFF
--- a/content/courses/tml_spring_26.md
+++ b/content/courses/tml_spring_26.md
@@ -34,22 +34,22 @@ The book will be useful for the course. However, the course materials are update
 <tr><th>#</th><th>Date</th><th>Content</th><th>Quiz</th><th>Project</th></tr>
 </thead>
 <tbody>
-<tr class="part-0"><td>L1</td><td>Mar 06</td><td>Orientation (14:30 - 16:00)</td><td>—</td><td><strong>Interest survey</strong></td></tr>
-<tr class="part-1"><td>L2</td><td>Mar 13</td><td><strong>I. Human → AI:</strong> Generalisation via Data</td><td>Quiz 0</td><td>—</td></tr>
-<tr class="part-1"><td>L3</td><td>Mar 20</td><td>Modularity & Composition</td><td>—</td><td><strong>Team formation due</strong></td></tr>
-<tr class="part-2"><td>L4</td><td>Mar 27</td><td><strong>II. AI → Human:</strong> Training Data Attribution I</td><td>Quiz 1</td><td>—</td></tr>
-<tr class="part-2"><td>L5</td><td>Apr 03</td><td>Training Data Attribution II</td><td>—</td><td>—</td></tr>
-<tr class="part-2"><td>L6</td><td>Apr 10</td><td>Explainability</td><td>—</td><td>—</td></tr>
-<tr class="part-2"><td>L7</td><td>Apr 17</td><td>Uncertainty I</td><td>Quiz 2</td><td>—</td></tr>
-<tr class="part-5"><td>L8</td><td>Apr 24</td><td>Proposal presentations</td><td>—</td><td><strong>Proposal due</strong></td></tr>
-<tr class="part-2"><td>L9</td><td>May 01</td><td>Uncertainty II</td><td>—</td><td>—</td></tr>
-<tr class="part-3"><td>L10</td><td>May 08</td><td><strong>III. Privacy & Security:</strong> Contextual Privacy</td><td>Quiz 3</td><td>—</td></tr>
-<tr class="part-3"><td>L11</td><td>May 15</td><td>Parametric Privacy</td><td>—</td><td>—</td></tr>
-<tr class="part-3"><td>L12</td><td>May 22</td><td>Security & Jailbreaking</td><td>Quiz 4</td><td>—</td></tr>
-<tr class="part-4"><td>L13</td><td>May 29</td><td><strong>IV. The Future:</strong> Agents & Synthesis</td><td>—</td><td>—</td></tr>
-<tr class="part-0"><td>L14</td><td>Jun 05</td><td>Course Wrap-up</td><td>Quiz 5</td><td>—</td></tr>
-<tr class="part-5"><td>L15</td><td>Jun 12</td><td>Project Co-working</td><td>—</td><td>—</td></tr>
-<tr class="part-5"><td>L16</td><td>Jun 19</td><td>Final Presentations</td><td>—</td><td><strong>Final report due</strong></td></tr>
+<tr class="part-0"><td>L1</td><td>Mar 06</td><td>Orientation (short session)</td><td>—</td><td><strong>Interest survey</strong></td></tr>
+<tr class="part-1"><td>L2</td><td>Mar 13</td><td><strong>I. Human → AI:</strong> ML Foundations & Generalisation Primer</td><td>Quiz 0 (trial)</td><td>—</td></tr>
+<tr class="part-1"><td>L3</td><td>Mar 20</td><td>Underspecification & Cues</td><td>—</td><td><strong>Team formation due</strong></td></tr>
+<tr class="part-1"><td>L4</td><td>Mar 27</td><td>LLM Communication & Modularity</td><td>—</td><td>—</td></tr>
+<tr class="part-2"><td>L5</td><td>Apr 03</td><td><strong>II. AI → Human:</strong> Explanation & XAI</td><td>Quiz 1</td><td>—</td></tr>
+<tr class="part-2"><td>L6</td><td>Apr 10</td><td>Attribution Methods</td><td>—</td><td>—</td></tr>
+<tr class="part-2"><td>L7</td><td>Apr 17</td><td>TDA Frontiers & Mechanistic Interpretability</td><td>—</td><td>—</td></tr>
+<tr class="part-5"><td>L8</td><td>Apr 24</td><td>Proposal presentations (midterm week)</td><td>—</td><td><strong>Proposal report due; Proposal presentation</strong></td></tr>
+<tr class="part-2"><td>L9</td><td>May 01</td><td>Uncertainty I (Aleatoric)</td><td>Quiz 2</td><td>—</td></tr>
+<tr class="part-2"><td>L10</td><td>May 08</td><td>Uncertainty II (Epistemic)</td><td>—</td><td>—</td></tr>
+<tr class="part-2"><td>L11</td><td>May 15</td><td>Uncertainty III (LLMs)</td><td>—</td><td>—</td></tr>
+<tr class="part-3"><td>L12</td><td>May 22</td><td><strong>III. Privacy & Security:</strong> Landscape & Data Privacy</td><td>Quiz 3</td><td>—</td></tr>
+<tr class="part-3"><td>L13</td><td>May 29</td><td>Contextual Privacy & Model Integrity</td><td>—</td><td>—</td></tr>
+<tr class="part-3"><td>L14</td><td>Jun 05</td><td>Adversarial Attacks & Jailbreaking</td><td>—</td><td>—</td></tr>
+<tr class="part-4"><td>L15</td><td>Jun 12</td><td><strong>IV. Synthesis & Wrap-up</strong></td><td>Quiz 4</td><td><strong>Final report due; Peer eval due</strong></td></tr>
+<tr class="part-5"><td>L16</td><td>Jun 19</td><td>Final Presentations</td><td>—</td><td><strong>Final presentation</strong></td></tr>
 </tbody>
 </table>
 
@@ -60,7 +60,7 @@ The book will be useful for the course. However, the course materials are update
 {{<table "table table-striped table-bordered">}}
 | Component | Weight |
 |---|---|
-| Quizzes 1-5 (6% each) | 30% |
+| Quizzes 1-4 (7.5% each) | 30% |
 | Proposal presentation | 10% |
 | Proposal report | 10% |
 | Final presentation | 25% |
@@ -68,28 +68,41 @@ The book will be useful for the course. However, the course materials are update
 | **Total** | **100%** |
 {{</table>}}
 
-Quiz 0 is a trial run and does not count towards the grade.
+### 5.2 Late submission policy
 
-### 5.2 Quizzes
+Late submissions are not accepted. A missed deadline counts as a zero.
+
+### 5.3 Quizzes
 
 - **Format:** Google Forms, accessible via QR code in class (link shared on Slack simultaneously).
 - **Timing:** Strict 10-minute window at the start of class.
 - **Structure:** 3 questions covering material from previous lectures. Attending lectures is essential.
+- **Quiz 0** is a trial run so students can get used to the format. It does not count towards the grade.
 
-### 5.3 Team projects
+### 5.4 Projects
+
+- **Deliverable:** 4-page report + 10 min presentation.
+- **Peer evaluation:** Mandatory form at the end. Distribute 100 points among your team members based on contribution. Unequal splits will affect individual grades.
+
+## 6. Team Projects
 
 - **Team size:** 3 students per team.
 - **Formation:**
   - Week 1: Interest survey.
   - Week 3: Teams finalised.
-- **Deliverable:** 4-page report + 10 min presentation.
-- **Peer evaluation:** Mandatory form at the end. Distribute 100 points among your team members based on contribution. Unequal splits will affect individual grades.
+- **Compute:** Each student receives a 50 USD Google Cloud Platform voucher for the project. Each team of three therefore has 150 USD credit.
 
-#### Example project topics
+### Example project topics
 
-Coming soon.
+Topics are open; students choose direction and methods. Examples of the kind of project that fits the course:
 
-## 6. Generative AI Policies
+1. **Test-time detection of prompt sensitivity.** Prior work has shown that VLMs are sensitive to prompt phrasing. The open question is whether we can detect *at test time* that a prediction is prompt-sensitive and flag it to the user, without access to ground truth. Propose and evaluate a detection method. Models: CLIP ViT-B/32, LLaVA-7B (both run on a single T4). Datasets: ImageNet, EuroSAT, or other zero-shot classification benchmarks. References: [PARC](https://arxiv.org/abs/2506.14808) (CVPR 2025, quantifying VLM prompt sensitivity), [WaffleCLIP](https://openaccess.thecvf.com/content/ICCV2023/papers/Roth_Waffling_Around_for_Performance_Visual_Classification_with_Random_Words_and_ICCV_2023_paper.pdf) (ICCV 2023, random descriptors match LLM-generated prompts).
+2. **Surfacing knowledge conflicts in RAG.** Recent work resolves parametric-contextual conflicts silently. An open problem is whether the system can instead *detect and surface* the conflict to the user, letting them decide. Build a conflict-detection pipeline and evaluate its precision. Models: Llama 3.1 8B or Mistral 7B with a FAISS index (A100 or T4 with quantisation). Datasets: Natural Questions or TriviaQA with synthetically altered retrieval passages. References: [FaithfulRAG](https://aclanthology.org/2025.acl-long.1062/) (ACL 2025, fact-level conflict modelling), [AdaCAD](https://aclanthology.org/2025.naacl-long.581/) (NAACL 2025, adaptive decoding for knowledge conflicts), [JuICE](https://proceedings.mlr.press/v267/li25c.html) (ICML 2025, test-time attention intervention).
+3. **Mechanistic vs data attribution for the same failure.** Recent work attributes model failures either to training data (TDA) or to internal mechanisms (layer-wise dynamics, circuit analysis). These perspectives are rarely compared. Pick a failure mode (e.g. hallucination, gender bias) and apply both attribution families to the same cases. Do they agree? Models: ViT-B on ImageNet for vision; Llama 3.1 8B or a smaller LLM for language. Datasets: task-specific failure sets you curate. References: [Accountability Attribution](https://icml.cc/virtual/2025/50882) (ICML 2025, tracing behaviour to training stages), [DDA](https://aclanthology.org/2024.emnlp-main.782/) (EMNLP 2024, influence functions with fitting error correction).
+4. **Confidence under distribution shift.** Methods like BaseCal and EAGLE improve calibration on in-distribution data. Less is known about how confidence estimates degrade under distribution shift or across multi-turn conversations. Evaluate existing calibration methods on shifted inputs and propose a detection strategy. Models: Llama 3.1 8B or Mistral 7B (sampling-based methods need ~20-50 forward passes per input; budget for this). Datasets: TriviaQA, MMLU with domain-shifted or adversarially perturbed variants. References: [IB-EDL](https://proceedings.iclr.cc/paper_files/paper/2025/hash/0cbdd1e6613c42fe975337671790f406-Abstract-Conference.html) (ICLR 2025, information-theoretic evidential calibration), [Multicalibration](https://proceedings.mlr.press/v235/detommaso24a.html) (ICML 2024, group-wise calibration for LLMs).
+5. **Paper reproduction.** Reproduce the key experiments of a published paper covered in the course. Verify the claims, test on a different model or dataset, and report where the results hold and where they break. Choose a paper whose experiments fit the compute budget.
+
+## 7. Generative AI Policies
 
 Students may use generative AI tools (e.g. LLMs, VLMs, image generators). However, you are solely responsible for all outputs you submit. We will apply heavy penalties for:
 - Hallucinated or factually incorrect outputs.
@@ -103,7 +116,9 @@ You must be ready to answer clarification requests from the lecturer or tutors a
 
 We do not tolerate very similar creative work among class members. AI tends to produce similar outputs across sessions and model families. Diversify your answers, especially for creative work. Suspicion of copied work will be penalised.
 
-## 7. Communication & Logistics
+## 8. Communication & Logistics
+
+**Language:** English
 
 **Lecturer:** [Seong Joon Oh](../../member/joon/)
 


### PR DESCRIPTION
- Restructure schedule: new L2 (ML Foundations), expanded uncertainty to three lectures, merged synthesis into L15
- Move proposal report deadline to L8 (with presentation)
- Remove final report draft deadline
- Redistribute quizzes: Quiz 0 trial + Quizzes 1-4 at 7.5% each
- Add example project topics with models, datasets, and references
- Add GCP compute info (150 USD per team)
- Add late submission policy, language, and Quiz 0 clarification
- Separate project logistics into its own section

Made-with: Cursor