### PR TITLE
Renumber TML 2026 lectures, skip Labor Day, add L11 video

### DIFF
--- a/content/courses/tml_spring_26.md
+++ b/content/courses/tml_spring_26.md
@@ -42,14 +42,14 @@ The book will be useful for the course. However, the course materials are update
 <tr class="part-2"><td>L6</td><td>Apr 10</td><td><a href="https://docs.google.com/presentation/d/1Kh3TrQRI-YXgJkLnfJhsHWYm_i1527yQDGXJOgUoYYk/edit?usp=sharing">Attribution Methods</a> · <a href="https://drive.google.com/file/d/1VcJgB5AtwEWcUPQaTugGdOH5R8HwrNVe/view?usp=sharing">Video</a></td><td>—</td></tr>
 <tr class="part-2"><td>L7</td><td>Apr 17</td><td><a href="https://docs.google.com/presentation/d/1ps8cC1DUJI6es_54diWD2UQGDwBUcMW3loYC4yinMEY/edit?usp=sharing">Training Data Attribution</a> · <a href="https://drive.google.com/file/d/1M5qcnP5Zgu3s4eUV-5KTarm9r07fWUtg/view?usp=sharing">Video</a></td><td>—</td></tr>
 <tr class="part-5"><td>L8</td><td>Apr 24</td><td>Proposal Presentations (Midterm Week) · <a href="https://drive.google.com/file/d/19Z5zALJaU3pVoQndEnqogDedcAdKh52f/view?usp=sharing">Video</a></td><td><strong>Proposal report due (23:59); Proposal presentation</strong></td></tr>
-<tr><td>L9</td><td>May 01</td><td>No class (Labor Day / 근로자의 날)</td><td>—</td></tr>
-<tr class="part-2"><td>L10</td><td>May 08</td><td><a href="https://docs.google.com/presentation/d/19ZC2Qo4yyaTzzQRSBRzYU5spTfy2N4RofggWivmxI8w/edit?usp=sharing">Uncertainty Estimation</a> · <a href="https://drive.google.com/file/d/1qoYgSQoL5PH87_2F2k0c80se2eCGNXEL/view?usp=sharing">Video</a></td><td>—</td></tr>
-<tr class="part-2"><td>L11</td><td>May 15</td><td><a href="https://docs.google.com/presentation/d/1FE_mT9W9bFybV98qtXz-xEY37sNvISIkXCntqj6uA44/edit?usp=sharing">Epistemic & Aleatoric Uncertainty</a> · <a href="https://drive.google.com/file/d/1xZs_1_nWn2fdXS8HqoyjAJBMrx_xSCdn/view?usp=sharing">Video</a></td><td>—</td></tr>
-<tr class="part-2"><td>L12</td><td>May 22</td><td>Uncertainty for Foundational Models</td><td>—</td></tr>
-<tr class="part-3"><td>L13</td><td>May 29</td><td><strong>III. Privacy & Security:</strong> Privacy & Data Protection</td><td>—</td></tr>
-<tr class="part-3"><td>L14</td><td>Jun 05</td><td>Security & Adversarial Robustness</td><td>—</td></tr>
-<tr class="part-4"><td>L15</td><td>Jun 12</td><td><strong>IV. Final Presentations (Part 1)</strong></td><td><strong>Final report due (12 June, 23:59)</strong></td></tr>
-<tr class="part-4"><td>L16</td><td>Jun 19</td><td><strong>Final Presentations (Part 2)</strong></td><td><strong>Peer eval due (23:59)</strong></td></tr>
+<tr><td>—</td><td>May 01</td><td>No class (Labor Day / 근로자의 날)</td><td>—</td></tr>
+<tr class="part-2"><td>L9</td><td>May 08</td><td><a href="https://docs.google.com/presentation/d/19ZC2Qo4yyaTzzQRSBRzYU5spTfy2N4RofggWivmxI8w/edit?usp=sharing">Uncertainty Estimation</a> · <a href="https://drive.google.com/file/d/1qoYgSQoL5PH87_2F2k0c80se2eCGNXEL/view?usp=sharing">Video</a></td><td>—</td></tr>
+<tr class="part-2"><td>L10</td><td>May 15</td><td><a href="https://docs.google.com/presentation/d/1FE_mT9W9bFybV98qtXz-xEY37sNvISIkXCntqj6uA44/edit?usp=sharing">Epistemic & Aleatoric Uncertainty</a> · <a href="https://drive.google.com/file/d/1xZs_1_nWn2fdXS8HqoyjAJBMrx_xSCdn/view?usp=sharing">Video</a></td><td>—</td></tr>
+<tr class="part-2"><td>L11</td><td>May 22</td><td><a href="https://docs.google.com/presentation/d/1FE_mT9W9bFybV98qtXz-xEY37sNvISIkXCntqj6uA44/edit?usp=sharing">Uncertainty for Foundational Models</a> · <a href="https://drive.google.com/file/d/1_T8a8qIaMDbgIZPKAFJAZyO8LtYsSnxl/view?usp=sharing">Video</a></td><td>—</td></tr>
+<tr class="part-3"><td>L12</td><td>May 29</td><td><strong>III. Privacy & Security:</strong> Privacy & Data Protection</td><td>—</td></tr>
+<tr class="part-3"><td>L13</td><td>Jun 05</td><td>Security & Adversarial Robustness</td><td>—</td></tr>
+<tr class="part-4"><td>L14</td><td>Jun 12</td><td><strong>IV. Final Presentations (Part 1)</strong></td><td><strong>Final report due (11 June, 23:59)</strong></td></tr>
+<tr class="part-4"><td>L15</td><td>Jun 19</td><td><strong>Final Presentations (Part 2)</strong></td><td><strong>Peer eval due (23:59)</strong></td></tr>
 </tbody>
 </table>
 
@@ -97,7 +97,7 @@ L8 (Apr 24). 5-minute lightning talk per team.
 
 ### Final report (35%)
 
-Due L15 (Jun 12, 23:59). 4 pages excluding references, ICML 2026 format.
+Due L14 (Jun 11, 23:59). 4 pages excluding references, ICML 2026 format.
 
 {{<table "table table-striped table-bordered">}}
 | Criterion | Description | 1 (Poor) | 5 (Excellent) |
@@ -111,7 +111,7 @@ Due L15 (Jun 12, 23:59). 4 pages excluding references, ICML 2026 format.
 
 ### Final presentation (35%)
 
-L16 (Jun 19). 10 minutes per team + Q&A.
+L14 (Jun 12) & L15 (Jun 19). 10 minutes per team + Q&A.
 
 {{<table "table table-striped table-bordered">}}
 | Criterion | Description | 1 (Poor) | 5 (Excellent) |


### PR DESCRIPTION
# Pull request

## Summary

<!-- One or two sentences on what this PR changes and why. -->

## Type of change

- [x] Content update (member, publication, course, opening, post)
- [ ] Layout or template change
- [ ] Configuration change
- [ ] Bug fix
- [ ] Other (describe below)

## Checklist

- [x] I previewed locally with `hugo server -D`.
- [x] Links, images, and references render correctly.
- [x] No files under `public/` were committed.
- [x] No private or unrelated files were committed.
- [x] The GitHub Actions build passes.

## Screenshots (if relevant)

<!-- Drop screenshots of the rendered change here. -->
